### PR TITLE
Gnome-Shell 3.6 Compat

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -120,7 +120,6 @@ TrashButton.prototype = {
       while ((file_info = children.next_file(null, null)) != null) {
         let item = new PopupMenu.PopupBaseMenuItem()
         let icon = new St.Icon({ gicon: file_info.get_icon(),
-                                 icon_type: St.IconType.FULLCOLOR,
                                  style_class: 'popup-menu-icon' });
         item.addActor(icon);
         item.addActor(new St.Label({ text: file_info.get_name() }));

--- a/extension.js
+++ b/extension.js
@@ -42,7 +42,6 @@ PopupMenuItem.prototype = {
         PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
 
         this.icon = new St.Icon({ icon_name: icon,
-                                  icon_type: St.IconType.FULLCOLOR,
                                   style_class: 'popup-menu-icon' });
         this.addActor(this.icon);
         this.label = new St.Label({ text: text });

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-   "shell-version": ["3.4"],
-   "version": "0.1",
+   "shell-version": ["3.6"],
+   "version": "0.2",
    "uuid": "gnome-shell-trash-extension",
    "name": "Trash",
    "description": "A Trash button for the GNOME shell panel",


### PR DESCRIPTION
Unfortunately this breaks compat with 3.4
(extension could still work but icons won't be visible)